### PR TITLE
Petites améliorations

### DIFF
--- a/contracts/Ethernal.sol
+++ b/contracts/Ethernal.sol
@@ -25,9 +25,9 @@ contract Moonolith is ERC1155U, IERC2981, Ownable {
     using SafeMath for uint256;
     uint256 _currentTokenId = 1;
 
-    bool private _gaslessTrading = true;
-    uint256 private _royaltyPartsPerMillion = 50_000;
     uint256 public _pricePerPix = 25000 gwei;
+    uint24 private _royaltyPartsPerMillion = 50_000;
+    bool private _gaslessTrading = true;
 
     string public constant name = 'Moonolith';
     string public constant symbol = 'MOON';

--- a/contracts/Ethernal.sol
+++ b/contracts/Ethernal.sol
@@ -142,7 +142,7 @@ contract Moonolith is ERC1155U, IERC2981, Ownable {
     }
 
     function _withdraw(address _address, uint256 _amount) private {
-        (bool success, ) = _address.call{value: _amount}("");
+        (bool success, ) = payable(_address).call{value: _amount}("");
         require(success, "Transfer failed.");
     }
 

--- a/contracts/Ethernal.sol
+++ b/contracts/Ethernal.sol
@@ -72,7 +72,7 @@ contract Moonolith is ERC1155U, IERC2981, Ownable {
         return (totalSupply(), _threshold, _klonSum, _pricePerPix);
     }
 
-    function uri(uint256 _tokenId) public view virtual override returns (string memory) {
+    function uri(uint256 _tokenId) public view override returns (string memory) {
 		require(_tokenId <= _currentTokenId, "URI query for nonexistent token");
 
 		bytes memory baseURI = (abi.encodePacked(
@@ -91,7 +91,7 @@ contract Moonolith is ERC1155U, IERC2981, Ownable {
 			
 	}
 
-    function supportsInterface(bytes4 interfaceId) public pure virtual override returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
         return interfaceId == type(IERC2981).interfaceId || super.supportsInterface(interfaceId);
     }
 


### PR DESCRIPTION
Hey !

- 61f0dc7: Dans deux fonctions, il y a les keywords virtual et override. Ca ne sert à rien de les mettre sur un même fonction, donc mieux vaut garder override (puisque le contract n'est pas hérité par un autre contract, donc le virtual est inutile).

- d8ea869: Juste mis l'adresse en payable, pas super utile mais c'est toujours bon de l'ajouter.

- 9916d1c: Alors là je vous conseil de regarder le début de [cette vidéo](https://youtu.be/Gg6nt3YW74o) pour mieux comprendre comment fonctionne le storage sur Solidity. Ici, j'ai changé `_royaltyPartsPerMillion` par un `uint24`, puisque apparement sa valeur ne dépassera jamais 1 million (selon la fonction `setRoyaltyPPM`), donc inutile de mettre un `uin256`, ça prend un slot de storage entier alors qu'on peut aussi mettre le booléen `_gaslessTrading` dans ce même slot. Ca permet d'optimiser les gas.